### PR TITLE
Add new aero rep code to build and tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -194,6 +194,7 @@ do_unit_test(chem_spec_data "PASS")
 do_unit_test(aero_phase_data "PASS")
 do_unit_test(jacobian "PASS")
 do_unit_test(aero_rep_single_particle "PASS")
+do_unit_test(aero_rep_single_particle_layers "PASS")
 do_unit_test(aero_rep_modal_binned_mass "PASS")
 do_unit_test(camp_core "PASS")
 
@@ -291,11 +292,13 @@ set(REACTIONS_SRC ${REACTIONS_F_SRC} ${REACTIONS_C_SRC})
 
 set(AEROSOL_REPS_F_SRC
         src/aero_reps/aero_rep_modal_binned_mass.F90
-        src/aero_reps/aero_rep_single_particle.F90)
+        src/aero_reps/aero_rep_single_particle.F90
+        src/aero_reps/aero_rep_single_particle_layers.F90)
 
 set(AEROSOL_REPS_C_SRC
         src/aero_reps/aero_rep_modal_binned_mass.c
-        src/aero_reps/aero_rep_single_particle.c)
+        src/aero_reps/aero_rep_single_particle.c
+        src/aero_reps/aero_rep_single_particle_layers.c)
 
 set_source_files_properties(${AEROSOL_REPS_F_SRC} PROPERTIES COMPILE_FLAGS
         ${STD_F_FLAGS})
@@ -603,6 +606,14 @@ add_executable(unit_test_aero_rep_single_particle
 	test/unit_aero_rep_data/test_aero_rep_single_particle.F90)
 
 target_link_libraries(unit_test_aero_rep_single_particle camplib)
+
+######################################################################
+# test_aero_rep_single_particle_layers
+
+add_executable(unit_test_aero_rep_single_particle_layers
+	test/unit_aero_rep_data/test_aero_rep_single_particle_layers.F90)
+
+target_link_libraries(unit_test_aero_rep_single_particle_layers camplib)
 
 ######################################################################
 # test_aero_rep_modal_binned_mass

--- a/src/aero_reps/aero_rep_single_particle_layers.c
+++ b/src/aero_reps/aero_rep_single_particle_layers.c
@@ -31,10 +31,10 @@
 #define NUM_ENV_PARAM_ MAX_PARTICLES_
 #define NUM_PHASE_(l) (int_data[NUM_INT_PROP_ + l] - 1)
 #define PHASE_STATE_ID_(p) (int_data[NUM_INT_PROP_ + TOTAL_NUM_PHASES_ + p] - 1)
-#define LAYER_STATE_ID_(l+1) (int_data[NUM_INT_PROP_ + TOTAL_NUM_LAYERS_ + l + 1] - 1)
+#define LAYER_STATE_ID_(l) (int_data[NUM_INT_PROP_ + TOTAL_NUM_LAYERS_ + l + 1] - 1)
 #define PHASE_MODEL_DATA_ID_(p) (int_data[NUM_INT_PROP_ + TOTAL_NUM_PHASES_ + p] - 1)
 #define PHASE_NUM_JAC_ELEM_(p) (int_data[NUM_INT_PROP_ + 2*TOTAL_NUM_PHASES_ + p] - 1)
-
+#if 0
 /** \brief Flag Jacobian elements used in calcualtions of mass and volume
  *
  * \param aero_rep_int_data Pointer to the aerosol representation integer data
@@ -453,3 +453,5 @@ void aero_rep_single_particle_set_number_update_data__n_m3(void *update_data,
   *new_particle_id = particle_id;
   *new_number_conc = number_conc;
 }
+
+#endif

--- a/test/unit_aero_rep_data/test_aero_rep_single_particle_layers.F90
+++ b/test/unit_aero_rep_data/test_aero_rep_single_particle_layers.F90
@@ -115,7 +115,7 @@ contains
     type(camp_core_t), pointer :: camp_core
     type(camp_state_t), pointer :: camp_state
     class(aero_rep_data_t), pointer :: aero_rep
-
+#if 0
 #ifdef CAMP_USE_JSON
 
     integer(kind=i_kind) :: i_spec, j_spec, i_rep, i_phase, i_layer 
@@ -319,7 +319,7 @@ contains
     deallocate(camp_core)
 
 #endif
-
+#endif
   end function build_aero_rep_data_set_test
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -329,7 +329,7 @@ contains
 
     !> CAMP-core
     type(camp_core_t), intent(inout) :: camp_core
-
+#if 0
     class(aero_rep_data_t), pointer :: aero_rep
     type(camp_state_t), pointer :: camp_state
     integer(kind=i_kind), allocatable :: phase_ids(:)
@@ -377,7 +377,7 @@ contains
                  ) .eq. 0
 
     deallocate(camp_state)
-
+#endif
   end function eval_c_func
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!

--- a/test/unit_aero_rep_data/test_aero_rep_single_particle_layers.F90
+++ b/test/unit_aero_rep_data/test_aero_rep_single_particle_layers.F90
@@ -16,7 +16,7 @@ program camp_test_aero_rep_data
 #endif
   use camp_aero_rep_data
   use camp_aero_rep_factory
-  use camp_aero_rep_single_particle
+  use camp_aero_rep_single_particle_layers
   use camp_mpi
   use camp_camp_core
   use camp_camp_state
@@ -105,7 +105,24 @@ contains
 
     deallocate(camp_solver_data)
 
+    call test_ordered_layer_array()
+
   end function run_camp_aero_rep_data_tests
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+  ! Tests the ordered layer array function
+  subroutine test_ordered_layer_array()
+
+    type(aero_rep_single_particle_layers_t) :: aero_rep
+
+    ! Here you can assemble input arguments for the ordered_layer_array()
+    ! function, call the function, and check the values of the output array
+
+    ! check individual values with this function:
+    call assert(468777371, "something" .eq. "something")
+
+  end subroutine test_ordered_layer_array
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 


### PR DESCRIPTION
Adds `aero_rep_single_particle_layers.F90` and `aero_rep_single_particle_layers.c` to the build, and includes a roughed-in set of tests for `aero_rep_single_particle_layers.F90` to the test suite.

There were a large number of syntax errors in the new source code files, so I commented out the body of most of the functions until these can be worked out. I would suggest first starting with uncommenting and debugging the `ordered_layer_array()` function. I added a roughed-in test for this function [here](https://github.com/mattldawson/camp_fork/blob/52b32742a1f8e9828a9fbed0e0653f0dd61b1009/test/unit_aero_rep_data/test_aero_rep_single_particle_layers.F90#L114-L125)

This pattern can be repeated for the remaining commented out functions