### PR TITLE
Update unique names function to have is_at_surface flag

### DIFF
--- a/src/aero_rep_data.F90
+++ b/src/aero_rep_data.F90
@@ -276,7 +276,8 @@ interface
   !> Get a list of unique names for each element on the
   !! \c camp_camp_state::camp_state_t::state_var array for this aerosol
   !! representation.
-  function unique_names(this, phase_name, tracer_type, spec_name)
+  function unique_names(this, phase_name, tracer_type, spec_name,             &
+      phase_is_at_surface)
     use camp_util,                                     only : string_t, i_kind
     import :: aero_rep_data_t
 
@@ -290,6 +291,8 @@ interface
     integer(kind=i_kind), optional, intent(in) :: tracer_type
     !> Aerosol-phase species name
     character(len=*), optional, intent(in) :: spec_name
+    !> Indicates if aerosol phase is at the surface of particle
+    logical, optional, intent(in) :: phase_is_at_surface
 
   end function unique_names
 
@@ -342,7 +345,7 @@ interface
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
   !> Get the number of instances of a specified aerosol phase
-  function num_phase_instances(this, phase_name, num_is_at_surface)
+  function num_phase_instances(this, phase_name, is_at_surface)
     use camp_util,                                       only : i_kind
     import :: aero_rep_data_t
 
@@ -353,7 +356,7 @@ interface
     !> Aerosol phase name
     character(len=*), intent(in) :: phase_name
     !> Indicates if aerosol phase is at the surface of particle
-    logical, intent(in), optional :: num_is_at_surface
+    logical, intent(in), optional :: is_at_surface
 
   end function num_phase_instances
 
@@ -511,10 +514,10 @@ contains
     if (present(is_at_surface)) then
       if (is_at_surface) then
         num_instances = this%num_phase_instances(phase_name, &
-                 num_is_at_surface = .true.)
+                 is_at_surface = .true.)
       else
         num_instances = this%num_phase_instances(phase_name, &
-                 num_is_at_surface = .false.)
+                 is_at_surface = .false.)
       end if
     else
       num_instances = this%num_phase_instances(phase_name)

--- a/src/aero_reps/aero_rep_modal_binned_mass.F90
+++ b/src/aero_reps/aero_rep_modal_binned_mass.F90
@@ -734,7 +734,8 @@ contains
   !!
   !! ... and for modes are:
   !!   - "mode name.phase name.species name"
-  function unique_names(this, phase_name, tracer_type, spec_name)
+  function unique_names(this, phase_name, tracer_type, spec_name,             &
+      phase_is_at_surface)
 
     !> List of unique names
     type(string_t), allocatable :: unique_names(:)
@@ -746,6 +747,8 @@ contains
     integer(kind=i_kind), optional, intent(in) :: tracer_type
     !> Aerosol-phase species name
     character(len=*), optional, intent(in) :: spec_name
+    !> Aerosol-phase species is at surface
+    logical, optional, intent(in) :: phase_is_at_surface
 
     integer(kind=i_kind) :: num_spec, i_spec, j_spec, i_phase, j_phase, &
                             i_section, i_bin
@@ -762,6 +765,12 @@ contains
       if (present(phase_name)) then
         curr_phase_name = this%aero_phase(i_phase)%val%name()
         if (phase_name.ne.curr_phase_name) cycle
+      end if
+
+      ! Filter by phase is at surface
+      if (present(phase_is_at_surface)) then
+        if (phase_is_at_surface .neqv.                                          &
+            this%aero_phase_is_at_surface(i_phase)) cycle
       end if
 
       ! Filter by spec name and/or tracer type
@@ -805,6 +814,15 @@ contains
         ! Filter by phase name
         if (present(phase_name)) then
           if (phase_name.ne.curr_phase_name) then
+            i_phase = i_phase + NUM_BINS_(i_section)
+            cycle
+          end if
+        end if
+
+        ! Filter by phase is at surface
+        if (present(phase_is_at_surface)) then
+          if (phase_is_at_surface .neqv.                                      &
+              this%aero_phase_is_at_surface(i_phase)) then
             i_phase = i_phase + NUM_BINS_(i_section)
             cycle
           end if
@@ -941,7 +959,7 @@ contains
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
   !> Get the number of instances of a specified aerosol phase.
-  function num_phase_instances(this, phase_name, num_is_at_surface)
+  function num_phase_instances(this, phase_name, is_at_surface)
 
     !> Number of instances of the aerosol phase
     integer(kind=i_kind) :: num_phase_instances
@@ -950,13 +968,13 @@ contains
     !> Aerosol phase name
     character(len=*), intent(in) :: phase_name
     !> Indicates if aerosol phase is at the surface of particle
-    logical, intent(in), optional :: num_is_at_surface
+    logical, intent(in), optional :: is_at_surface
 
     integer(kind=i_kind) :: i_phase
 
-    if (present(num_is_at_surface)) then
-      if (num_is_at_surface) then
-        num_phase_instances = 0
+    num_phase_instances = 0
+    if (present(is_at_surface)) then
+      if (is_at_surface) then
         do i_phase = 1, size(this%aero_phase)
           if (this%aero_phase(i_phase)%val%name().eq.phase_name .and. &
               this%aero_phase_is_at_surface(i_phase)) then
@@ -964,7 +982,6 @@ contains
           end if
         end do
       else
-        num_phase_instances = 0
         do i_phase = 1, size(this%aero_phase)
           if (this%aero_phase(i_phase)%val%name().eq.phase_name .and. &
               .not. this%aero_phase_is_at_surface(i_phase)) then
@@ -975,7 +992,6 @@ contains
         end do 
       end if
     else
-      num_phase_instances = 0
       do i_phase = 1, size(this%aero_phase)
         if (this%aero_phase(i_phase)%val%name().eq.phase_name) then
           num_phase_instances = num_phase_instances + 1

--- a/src/rxns/rxn_SIMPOL_phase_transfer.F90
+++ b/src/rxns/rxn_SIMPOL_phase_transfer.F90
@@ -246,7 +246,8 @@ contains
       ! Get the unique names in this aerosol representation for the
       ! partitioning species
       unique_spec_names = aero_rep(i_aero_rep)%val%unique_names( &
-              phase_name = phase_name, spec_name = aero_spec_name)
+              phase_name = phase_name, spec_name = aero_spec_name, &
+              phase_is_at_surface = .true.)
 
       ! Skip aerosol representations that do not contain this phase
       if (.not.allocated(unique_spec_names)) cycle
@@ -308,12 +309,14 @@ contains
       ! Get the unique names in this aerosol representation for the
       ! partitioning species
       unique_spec_names = aero_rep(i_aero_rep)%val%unique_names( &
-              phase_name = phase_name, spec_name = aero_spec_name)
+              phase_name = phase_name, spec_name = aero_spec_name, &
+              phase_is_at_surface = .true.)
 
       ! Find the corresponding activity coefficients, if specified
       if (has_act_coeff) then
         unique_act_names = aero_rep(i_aero_rep)%val%unique_names( &
-              phase_name = phase_name, spec_name = act_name)
+              phase_name = phase_name, spec_name = act_name, &
+              phase_is_at_surface = .true.)
         call assert_msg(236251734, size(unique_act_names).eq. &
                         size(unique_spec_names), &
                         "Mismatch of SIMPOL species and activity coeffs"// &

--- a/test/unit_aero_rep_data/test_aero_rep_single_particle.F90
+++ b/test/unit_aero_rep_data/test_aero_rep_single_particle.F90
@@ -215,19 +215,19 @@ contains
         max_part = aero_rep%maximum_computational_particles()
         jam_phase_instance = 0
         !check value
-        print *, "jam_instances ", aero_rep%num_phase_instances(phase_name_test, num_is_at_surface = .false.)
+        print *, "jam_instances ", aero_rep%num_phase_instances(phase_name_test, is_at_surface = .false.)
         call assert(417730478, 3 .eq. max_part)
         call assert(493602373, jam_phase_instance .eq. aero_rep%num_phase_instances(phase_name_test, &
-                                                         num_is_at_surface = .true.))
+                                                         is_at_surface = .true.))
 
         phase_name_test = "bread"
         num_bread = 1
         bread_phase_instance = num_bread * max_part
         !check value
         print *, bread_phase_instance
-        print *, "bread_instqnces ", aero_rep%num_phase_instances(phase_name_test, num_is_at_surface = .true.)
+        print *, "bread_instqnces ", aero_rep%num_phase_instances(phase_name_test, is_at_surface = .true.)
         call assert(734138496, bread_phase_instance .eq. aero_rep%num_phase_instances(phase_name_test, &
-                                                         num_is_at_surface = .true.))
+                                                         is_at_surface = .true.))
 
       class default
         call die_msg(519535557, rep_name)

--- a/test/unit_rxn_data/test_rxn_SIMPOL_phase_transfer.F90
+++ b/test/unit_rxn_data/test_rxn_SIMPOL_phase_transfer.F90
@@ -60,7 +60,9 @@ contains
     camp_solver_data => camp_solver_data_t()
 
     if (camp_solver_data%is_solver_available()) then
+      write(*,*) "Running SIMPOL phase transfer reaction test for single particle aerosol"
       passed = run_SIMPOL_phase_transfer_test(1)
+      write(*,*) "Running SIMPOL phase transfer reaction test for modal aerosol"
       passed = passed .and. run_SIMPOL_phase_transfer_test(2)
     else
       call warn_msg(713064651, "No solver available")

--- a/test/unit_rxn_data/test_rxn_SIMPOL_phase_transfer.F90
+++ b/test/unit_rxn_data/test_rxn_SIMPOL_phase_transfer.F90
@@ -60,9 +60,7 @@ contains
     camp_solver_data => camp_solver_data_t()
 
     if (camp_solver_data%is_solver_available()) then
-      write(*,*) "Running SIMPOL phase transfer reaction test for single particle aerosol"
       passed = run_SIMPOL_phase_transfer_test(1)
-      write(*,*) "Running SIMPOL phase transfer reaction test for modal aerosol"
       passed = passed .and. run_SIMPOL_phase_transfer_test(2)
     else
       call warn_msg(713064651, "No solver available")


### PR DESCRIPTION
I think the error was coming from the fact that the `unique_names()` function was returning names for all species in a given phase (not just those at the surface, if that's what are needed).

This PR updates the `unique_names()` function to include an optional `phase_is_at_surface` flag, similar to that for `num_phase_instances()`.

Before you submit the final PR to `main`, we should probably add a test of the new `unique_names()` flag.

The SIMPOL test still fails, but now it fails because the output doesn't match the analytical result, so it's probably a problem with the configuration.